### PR TITLE
Fix internal compiler error on MSVC

### DIFF
--- a/patterns.hpp
+++ b/patterns.hpp
@@ -138,7 +138,7 @@ namespace patterns
 	template<class... Pattern>
 	constexpr std::array<PatternWrapper, sizeof...(Pattern)> make_pattern_array(const Pattern&... patterns)
 	{
-		return{ PatternWrapper(patterns)... };
+		return{ patterns... };
 	}
 
 	#define CONCATENATE1(arg1, arg2) arg1 ## arg2


### PR DESCRIPTION
Despite able to be compiled on clang and GCC, MSVC will error if a copy constructor is not provided and we try to make a copy.