### PR TITLE
add getters of module base and length

### DIFF
--- a/IHookableModule.cpp
+++ b/IHookableModule.cpp
@@ -12,6 +12,16 @@ std::wstring IHookableModule::GetName()
 	return m_Name;
 }
 
+void* IHookableModule::GetBase()
+{
+	return m_Base;
+}
+
+size_t IHookableModule::GetLength()
+{
+	return m_Length;
+}
+
 void IHookableModule::Clear()
 {
 	m_Handle = nullptr;

--- a/IHookableModule.hpp
+++ b/IHookableModule.hpp
@@ -14,6 +14,8 @@ public:
 	virtual bool CanHook(const std::wstring& moduleFullName) = 0;
 	virtual void* GetHandle();
 	virtual std::wstring GetName();
+	virtual void* GetBase();
+	virtual size_t GetLength();
 
 	virtual void Hook(const std::wstring& moduleName, void* moduleHandle, void* moduleBase, size_t moduleLength, bool needToIntercept) = 0;
 	virtual void Unhook() = 0;


### PR DESCRIPTION
I'd like to be able to check if a pointer actually points to something inside of a module programmatically instead of just crashing when I have a bad pointer. This also lets me do searches for offsets in game objects.