### PR TITLE
Don't use RTLD_NOLOAD alone in the dlopen calls

### DIFF
--- a/Linux/MemUtils_linux.cpp
+++ b/Linux/MemUtils_linux.cpp
@@ -127,7 +127,7 @@ namespace MemUtils
 		dl_iterate_phdr([](dl_phdr_info* i, size_t s, void* data) -> int {
 			if (i->dlpi_name[0])
 			{
-				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_NOLOAD);
+				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
 				ORIG_dlclose(handle);
 
 				auto p = reinterpret_cast<std::pair<void*, const std::wstring*>*>(data);
@@ -155,7 +155,7 @@ namespace MemUtils
 		dl_iterate_phdr([](dl_phdr_info* i, size_t s, void* data) -> int {
 			if (i->dlpi_name[0])
 			{
-				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_NOLOAD);
+				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
 				ORIG_dlclose(handle);
 
 				auto p = reinterpret_cast<std::pair<void*, std::string>*>(data);
@@ -176,7 +176,7 @@ namespace MemUtils
 		dl_iterate_phdr([](dl_phdr_info* i, size_t s, void* data) -> int {
 			if (i->dlpi_name[0])
 			{
-				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_NOLOAD);
+				auto handle = ORIG_dlopen(i->dlpi_name, RTLD_LAZY | RTLD_NOLOAD);
 				ORIG_dlclose(handle);
 				reinterpret_cast<std::vector<void*>*>(data)->push_back(handle);
 			}


### PR DESCRIPTION
As per investigation in https://github.com/YaLTeR/BunnymodXT/issues/326, 

TLDR: `dlopen()` here fails and returns `NULL` on glibc 2.36+ (subsequently, `dlclose(thatNULLfromthedlopencall)` then segfaults), even though it should be more like `invalid mode for dlopen(): Invalid argument` (this should be true even for older glibc, so no idea why it worked until now, like I mentioned in the issue, maybe the libraries were already somehow loaded before, so it didn't matter with older versions?) but whatever. 

Like we mentioned in the Discord earlier, OR'ing it with RTLD_LAZY (or RTLD_NOW) fixes this and BXT injects fine and everything works flawlessly, so let's just do this?
