### PR TITLE
Allow MSVC to use the ISO conforming preprocessor

### DIFF
--- a/autogen_pattern_macros.py
+++ b/autogen_pattern_macros.py
@@ -47,17 +47,17 @@ def write_FOR_EACH2_ARG_N_REC(fp, n, i):
         write_FOR_EACH2_ARG_N_REC(fp,n,i+1)
 
 def write_file(n):
-    with open("patterns_macros.hpp", "w") as fp:
+    with open("patterns_macros.hpp", "w", newline='\n') as fp:
         fp.write("// This file has been automatically generated using autogen_pattern_macros.py\n\n")
         fp.write("/*\n\
 * Concatenate with empty because otherwise the MSVC preprocessor\n\
 * puts all __VA_ARGS__ arguments into the first one.\n*/\n")
         write_make_patterns(fp, n, 1)
-        fp.write("#ifdef _MSC_VER\n");
+        fp.write("#if !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL\n");
         write_name_patterns(fp, n, 1, True)
         fp.write("#else\n");
         write_name_patterns(fp, n, 1, False)  
-        fp.write("#endif // _MSC_VER\n");
+        fp.write("#endif // !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL\n");
         write_FOR_EACH2_ARG_N(fp, n)
         write_FOR_EACH2_RSEQ_N(fp, n)
 

--- a/patterns_macros.hpp
+++ b/patterns_macros.hpp
@@ -66,7 +66,7 @@
 #define MAKE_PATTERN_60(name, pattern_name, pattern, ...) static constexpr auto ptn_ ## name ## _60 = PATTERN(pattern); CONCATENATE(MAKE_PATTERN_59(name, __VA_ARGS__),)
 #define MAKE_PATTERN_61(name, pattern_name, pattern, ...) static constexpr auto ptn_ ## name ## _61 = PATTERN(pattern); CONCATENATE(MAKE_PATTERN_60(name, __VA_ARGS__),)
 #define MAKE_PATTERN_62(name, pattern_name, pattern, ...) static constexpr auto ptn_ ## name ## _62 = PATTERN(pattern); CONCATENATE(MAKE_PATTERN_61(name, __VA_ARGS__),)
-#ifdef _MSC_VER
+#if !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
 #define NAME_PATTERN_1(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _1 }
 #define NAME_PATTERN_2(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _2 },CONCATENATE(NAME_PATTERN_1(name, __VA_ARGS__),)
 #define NAME_PATTERN_3(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _3 },CONCATENATE(NAME_PATTERN_2(name, __VA_ARGS__),)
@@ -192,6 +192,6 @@
 #define NAME_PATTERN_60(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _60 },NAME_PATTERN_59(name, __VA_ARGS__)
 #define NAME_PATTERN_61(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _61 },NAME_PATTERN_60(name, __VA_ARGS__)
 #define NAME_PATTERN_62(name, pattern_name, pattern, ...) PatternWrapper{ pattern_name, ptn_ ## name ## _62 },NAME_PATTERN_61(name, __VA_ARGS__)
-#endif // _MSC_VER
+#endif // !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
 #define FOR_EACH2_ARG_N( __1, __1_, __2, __2_, __3, __3_, __4, __4_, __5, __5_, __6, __6_, __7, __7_, __8, __8_, __9, __9_, __10, __10_, __11, __11_, __12, __12_, __13, __13_, __14, __14_, __15, __15_, __16, __16_, __17, __17_, __18, __18_, __19, __19_, __20, __20_, __21, __21_, __22, __22_, __23, __23_, __24, __24_, __25, __25_, __26, __26_, __27, __27_, __28, __28_, __29, __29_, __30, __30_, __31, __31_, __32, __32_, __33, __33_, __34, __34_, __35, __35_, __36, __36_, __37, __37_, __38, __38_, __39, __39_, __40, __40_, __41, __41_, __42, __42_, __43, __43_, __44, __44_, __45, __45_, __46, __46_, __47, __47_, __48, __48_, __49, __49_, __50, __50_, __51, __51_, __52, __52_, __53, __53_, __54, __54_, __55, __55_, __56, __56_, __57, __57_, __58, __58_, __59, __59_, __60, __60_, __61, __61_, __62, __62_, N, ...) N
 #define FOR_EACH2_RSEQ_N 62, 0, 61, 0, 60, 0, 59, 0, 58, 0, 57, 0, 56, 0, 55, 0, 54, 0, 53, 0, 52, 0, 51, 0, 50, 0, 49, 0, 48, 0, 47, 0, 46, 0, 45, 0, 44, 0, 43, 0, 42, 0, 41, 0, 40, 0, 39, 0, 38, 0, 37, 0, 36, 0, 35, 0, 34, 0, 33, 0, 32, 0, 31, 0, 30, 0, 29, 0, 28, 0, 27, 0, 26, 0, 25, 0, 24, 0, 23, 0, 22, 0, 21, 0, 20, 0, 19, 0, 18, 0, 17, 0, 16, 0, 15, 0, 14, 0, 13, 0, 12, 0, 11, 0, 10, 0, 9, 0, 8, 0, 7, 0, 6, 0, 5, 0, 4, 0, 3, 0, 2, 0, 1


### PR DESCRIPTION
If you compile with /Zc:preprocessor (or "C/C++ -> Preprocessor -> Use Standard Conforming Processor -> Yes" in the project properties), we need to use the standard macros instead of the msvc ones. There's a preprocessor flag that indicates which MSVC preprocessor is being used.

Can't use __VA_OPT__ in MSVC without the new preprocessor