### PR TITLE
MemUtils: Add explicit template<> to fix GCC warning

### DIFF
--- a/MemUtils.hpp
+++ b/MemUtils.hpp
@@ -218,6 +218,7 @@ namespace MemUtils
 	{
 		MarkAsExecutable(reinterpret_cast<void*>(addr));
 	}
+	template<>
 	void MarkAsExecutable(void* addr);
 
 	void ReplaceBytes(void* addr, size_t length, const uint8_t* newBytes);


### PR DESCRIPTION
GCC thinks it's a recursive call otherwise.

@lipsanen I think this is correct, right?